### PR TITLE
Add script for reproducible AERMOD downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ brew unpin aermet
 brew unpin aermap
 ```
 
+### Fetching Source Archives with Checksums
+
+For reproducible builds you can download the official AERMOD source and record
+its SHA-256 checksum. The `scripts/fetch_latest_aermod.sh` helper script
+automates this:
+
+```bash
+./scripts/fetch_latest_aermod.sh        # downloads the newest release
+# or specify a version number
+./scripts/fetch_latest_aermod.sh 24142
+
+# Afterwards add the new files to version control
+git add downloads/aermod_*.zip checksums/aermod_*.sha256
+git commit -m "Add AERMOD source and checksum"
+```
+
+When a new version is released update the script by changing the VERSION
+argument or letting it scrape the latest version from EPA's SCRAM website. The
+checksum files kept in `checksums/` allow others to verify they are building
+from the same archive.
+
 ## Technical Details
 
 These formulas compile the official EPA source code using gfortran (from GCC). The compilation process:

--- a/scripts/fetch_latest_aermod.sh
+++ b/scripts/fetch_latest_aermod.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Fetch the latest AERMOD source code and store its checksum
+# Usage: ./scripts/fetch_latest_aermod.sh [VERSION]
+# If VERSION is not supplied, attempt to scrape the latest release number from
+the EPA SCRAM page.
+
+set -euo pipefail
+
+BASE_URL="https://gaftp.epa.gov/Air/aqmg/SCRAM/models/preferred/aermod"
+SCRAM_PAGE="https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
+
+if [[ $# -gt 0 ]]; then
+  VERSION="$1"
+else
+  VERSION=$(curl -fsSL "$SCRAM_PAGE" | grep -oE 'Source Code \(v[0-9]+\) \(ZIP\)' | head -n1 | grep -oE '[0-9]+')
+fi
+
+ARCHIVE="Source Code (v${VERSION}) (ZIP)"
+URL="${BASE_URL}/${ARCHIVE}"
+
+mkdir -p downloads checksums
+
+out_zip="downloads/aermod_${VERSION}.zip"
+
+curl -L -o "$out_zip" "$URL"
+
+sha256sum "$out_zip" | awk '{print $1 "  aermod_${VERSION}.zip"}' > "checksums/aermod_${VERSION}.sha256"
+
+echo "Downloaded $out_zip and wrote checksum to checksums/aermod_${VERSION}.sha256"
+
+echo "Add the new files to git:" >&2
+echo "  git add $out_zip checksums/aermod_${VERSION}.sha256" >&2
+


### PR DESCRIPTION
## Summary
- provide a helper script `fetch_latest_aermod.sh` to download the newest AERMOD release and generate a SHA-256 checksum
- document how to use the script in the README

## Testing
- `git status --short`