### PR TITLE
Fix style issues in formula descriptions and system calls

### DIFF
--- a/Formula/aermap.rb
+++ b/Formula/aermap.rb
@@ -1,5 +1,5 @@
 class Aermap < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
@@ -174,12 +174,12 @@ class Aermap < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -199,10 +199,10 @@ class Aermap < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermap", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermap@24142.rb
+++ b/Formula/aermap@24142.rb
@@ -1,5 +1,5 @@
 class AermapAT24142 < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
@@ -83,22 +83,22 @@ class AermapAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermap", *link_flags, *object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermet.rb
+++ b/Formula/aermet.rb
@@ -1,5 +1,5 @@
 class Aermet < Formula
-  desc "EPA AERMET meteorological preprocessor (built from source)"
+  desc "EPA meteorological preprocessor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/meteorological-processors-and-accessory-programs#aermet"
   license :public_domain
   version "24142"
@@ -139,12 +139,12 @@ class Aermet < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -164,10 +164,10 @@ class Aermet < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermet", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermet", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermet")
+    bin.install "aermet"
   end
 
   test do

--- a/Formula/aermet@24142.rb
+++ b/Formula/aermet@24142.rb
@@ -1,5 +1,5 @@
 class AermetAT24142 < Formula
-  desc "EPA AERMET meteorological preprocessor (built from source)"
+  desc "EPA meteorological preprocessor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/meteorological-processors-and-accessory-programs#aermet"
   license :public_domain
   version "24142"
@@ -73,22 +73,22 @@ class AermetAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermet", *link_flags, *object_files)
+    system "gfortran", "-o", "aermet", *link_flags, *object_files
 
     # Install
-    bin.install("aermet")
+    bin.install "aermet"
   end
 
   test do

--- a/Formula/aermod.rb
+++ b/Formula/aermod.rb
@@ -1,5 +1,5 @@
 class Aermod < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
   version "24142"
@@ -182,12 +182,12 @@ class Aermod < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -207,7 +207,7 @@ class Aermod < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermod", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermod", *link_flags, *unique_object_files
     
     # Handle the executable
     if File.exist?("aermod.exe")

--- a/Formula/aermod@24142.rb
+++ b/Formula/aermod@24142.rb
@@ -1,5 +1,5 @@
 class AermodAT24142 < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
   version "24142"
@@ -91,22 +91,22 @@ class AermodAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermod", *link_flags, *object_files)
+    system "gfortran", "-o", "aermod", *link_flags, *object_files
 
     # Install
-    bin.install("aermod")
+    bin.install "aermod"
   end
 
   test do


### PR DESCRIPTION
## Summary
- remove formula names from descriptions
- drop parentheses from system calls

## Testing
- `ruby -c Formula/*.rb`

------
https://chatgpt.com/codex/tasks/task_b_683a46066310832b8de71acd49eaa1cc