### PR TITLE
Fix style issues in formulas

### DIFF
--- a/Formula/aermap.rb
+++ b/Formula/aermap.rb
@@ -1,7 +1,9 @@
 class Aermap < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
+  require "English"
+  require "set"
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
   version "24142"
   sha256 "4b34b39fe0039db114e3e78e3b6faa4797a5f8ee8ca0771db030a9b93ab3bed6"
@@ -21,9 +23,7 @@ class Aermap < Formula
     if build.with?("version")
       version_arg = build.value("version")
       version_resource = "aermap_#{version_arg}"
-      unless resource_exists?(version_resource)
-        odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.")
-      end
+      odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.") unless resource_exists?(version_resource)
       resource(version_resource).stage { buildpath.install(Dir["*"]) }
     end
 
@@ -40,24 +40,24 @@ class Aermap < Formula
     compile_flags = ["-O2", "-fno-common"]  # Add -fno-common to prevent duplicate symbols
     compile_flags += %w[-fbounds-check -Wuninitialized] if build.with?("bounds-check")
     link_flags = %w[-O2]
-    
+
     # Clean up any existing object files to prevent conflicts
     FileUtils.rm_f Dir["*.o", "*.mod"]
-    
+
     # Check if we have a batch file to use as reference
     bat_file = "#{source_dir}/gfortran-aermap-64bit.bat"
-    
+
     # Track compiled object files to avoid duplicates
     compiled_objects = Set.new
-    
+
     if File.exist?(bat_file)
       ohai "Found batch file, analyzing it for compilation steps"
       bat_content = File.read(bat_file)
-      
+
       # Find both compilation and linking commands
       compile_commands = []
       link_command = nil
-      
+
       # Extract compile commands in order
       bat_content.each_line do |line|
         if line =~ /gfortran\s+.*-c.*\.f/i
@@ -67,17 +67,17 @@ class Aermap < Formula
           link_command = line
         end
       end
-      
+
       # If we found compile commands, use them
       if compile_commands.any?
         ohai "Found #{compile_commands.size} compile commands in batch file"
         source_files = compile_commands
-        
+
         # If we found a link command, check if it specifies the object files in a specific order
         if link_command
           ohai "Found link command, analyzing object file order"
           link_objects = link_command.scan(/\s+([a-zA-Z0-9_]+\.o)\b/i).flatten
-          
+
           if link_objects.any?
             ohai "Using object file order from link command: #{link_objects.join(", ")}"
             # Convert back to source file names for compilation - try both .f and .f90 extensions
@@ -86,7 +86,7 @@ class Aermap < Formula
               base_name = obj.sub(/\.o$/, '')
               f_file = "#{base_name}.f"
               f90_file = "#{base_name}.f90"
-              
+
               if File.exist?(f_file)
                 source_files_from_link << f_file
               elsif File.exist?(f90_file)
@@ -96,7 +96,7 @@ class Aermap < Formula
                 source_files_from_link << f_file  # Default to .f extension
               end
             end
-            
+
             # Make sure we have all files - add any missing ones from compile_commands
             missing_files = compile_commands - source_files_from_link
             if missing_files.any?
@@ -114,7 +114,7 @@ class Aermap < Formula
     else
       # Define the exact compilation order based on the batch file
       ohai "No batch file found, using predefined compilation order"
-      
+
       # This is the standard order from gfortran-aermap-64bit.bat
       ordered_files = %w[
         mod_main1.f
@@ -139,70 +139,70 @@ class Aermap < Formula
         sub_utmgeo.f
         sub_read_tifftags.f
       ]
-      
+
       # Filter to only include files that exist
       all_source_files = Dir["*.f", "*.f90"]
       existing_ordered_files = ordered_files.select { |f| all_source_files.include?(f) }
-      
+
       # Add any remaining files not in our ordered list
       remaining_files = all_source_files - existing_ordered_files
       source_files = existing_ordered_files + remaining_files
-      
+
       ohai "Compile order: #{source_files.join(", ")}"
     end
-    
+
     # Stop if no source files found
     if source_files.empty?
       odie "No source files found. Check ZIP structure."
     end
-    
+
     ENV.deparallelize
-    
+
     # Compile all files in the determined order
     object_files = []
     source_files.each do |src|
       # Skip files that don't exist (in case we extracted names from a batch file)
       next unless File.exist?(src)
-      
+
       obj_name = File.basename(src, File.extname(src)) + ".o"
-      
+
       # Skip if we've already compiled this file
       if compiled_objects.include?(obj_name)
         ohai "Skipping duplicate compilation of #{src}"
         next
       end
-      
+
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
-      
+      system "gfortran", "-c", "-J.", *compile_flags, src
+
       # Check if compilation succeeded
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
-      
+
       # Add to our tracking sets
       compiled_objects.add(obj_name)
       object_files << obj_name if File.exist?(obj_name)
     end
-    
+
     if object_files.empty?
       odie "No object files were generated. Compilation failed."
     end
-    
+
     # Ensure no duplicate object files in the link step
     unique_object_files = object_files.uniq
-    
+
     # Debug output to show what we're linking
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
-    
+
     # Link only unique object files
-    system("gfortran", "-o", "aermap", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermap@24142.rb
+++ b/Formula/aermap@24142.rb
@@ -1,7 +1,9 @@
 class AermapAT24142 < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
+  require "English"
+  require "set"
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
   version "24142"
   sha256 "4b34b39fe0039db114e3e78e3b6faa4797a5f8ee8ca0771db030a9b93ab3bed6"
@@ -21,9 +23,7 @@ class AermapAT24142 < Formula
     if build.with?("version")
       version_arg = build.value("version")
       version_resource = "aermap_#{version_arg}"
-      unless resource_exists?(version_resource)
-        odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.")
-      end
+      odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.") unless resource_exists?(version_resource)
       resource(version_resource).stage { buildpath.install(Dir["*"]) }
     end
 
@@ -66,39 +66,39 @@ class AermapAT24142 < Formula
       sub_utmgeo.f
       sub_read_tifftags.f
     ]
-    
+
     # Filter to only include files that exist
     all_source_files = Dir["*.f", "*.f90"]
     existing_ordered_files = ordered_files.select { |f| all_source_files.include?(f) }
-    
+
     # Add any remaining files not in our ordered list
     remaining_files = all_source_files - existing_ordered_files
     source_files = existing_ordered_files + remaining_files
-    
+
     if source_files.empty?
       odie "No source files found. Check ZIP structure."
     end
-    
+
     ENV.deparallelize
-    
+
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
-      
+      system "gfortran", "-c", "-J.", *compile_flags, src
+
       # Check if compilation succeeded
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermap", *link_flags, *object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermet.rb
+++ b/Formula/aermet.rb
@@ -1,7 +1,9 @@
 class Aermet < Formula
-  desc "EPA AERMET meteorological preprocessor (built from source)"
+  desc "EPA meteorological preprocessor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/meteorological-processors-and-accessory-programs#aermet"
   license :public_domain
+  require "English"
+  require "set"
   version "24142"
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/met/aermet/aermet_source.zip"
   sha256 "0e13af282c990dd08ec535d9476b850b559fe190a48942f2d0e2be705b43fab2"
@@ -21,9 +23,7 @@ class Aermet < Formula
     if build.with?("version")
       version_arg = build.value("version")
       version_resource = "aermet_#{version_arg}"
-      if !resource_exists?(version_resource)
-        odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.")
-      end
+      odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.") unless resource_exists?(version_resource)
       resource(version_resource).stage { buildpath.install(Dir["*"]) }
     end
 
@@ -40,24 +40,24 @@ class Aermet < Formula
     compile_flags = ["-O2", "-fno-common"]  # Add -fno-common to prevent duplicate symbols
     compile_flags += %w[-fbounds-check -Wuninitialized] if build.with?("bounds-check")
     link_flags = %w[-O2]
-    
+
     # Clean up any existing object files to prevent conflicts
     FileUtils.rm_f Dir["*.o", "*.mod"]
-    
+
     # Check if we have a batch file to use as reference
     bat_file = "#{source_dir}/gfortran-aermet_allwarn.bat"
-    
+
     # Track compiled object files to avoid duplicates
     compiled_objects = Set.new
-    
+
     if File.exist?(bat_file)
       ohai "Found batch file, analyzing it for compilation steps"
       bat_content = File.read(bat_file)
-      
+
       # Find both compilation and linking commands
       compile_commands = []
       link_command = nil
-      
+
       # Extract compile commands in order
       bat_content.each_line do |line|
         if line =~ /gfortran\s+-c.*\.f/i
@@ -67,22 +67,22 @@ class Aermet < Formula
           link_command = line
         end
       end
-      
+
       # If we found compile commands, use them
       if compile_commands.any?
         ohai "Found #{compile_commands.size} compile commands in batch file"
         source_files = compile_commands
-        
+
         # If we found a link command, check if it specifies the object files in a specific order
         if link_command
           ohai "Found link command, analyzing object file order"
           link_objects = link_command.scan(/\s+([a-zA-Z0-9_]+\.o)\b/i).flatten
-          
+
           if link_objects.any?
             ohai "Using object file order from link command: #{link_objects.join(", ")}"
             # Convert back to source file names for compilation
             source_files_from_link = link_objects.map { |o| o.sub(/\.o$/, '.f90') }
-            
+
             # Make sure we have all files - add any missing ones from compile_commands
             missing_files = compile_commands - source_files_from_link
             if missing_files.any?
@@ -100,74 +100,74 @@ class Aermet < Formula
     else
       # Try to determine a sensible compile order
       ohai "No batch file found, determining module dependencies"
-      
+
       # Define the exact order for critical modules
       critical_modules = %w[mod_file_units.f90 mod_main1.f90 mod_upperair.f90 mod_surface.f90 mod_onsite.f90 mod_pbl.f90 mod_read_input.f90 mod_reports.f90 mod_misc.f90]
-      
+
       # Filter out modules that don't exist in our directory
       existing_critical_modules = critical_modules.select { |f| File.exist?(f) }
-      
+
       # Get all remaining files that aren't in our critical list
       other_files = Dir["*.f", "*.f90"].sort - existing_critical_modules
-      
+
       # Use the specific order for modules, followed by other files
       source_files = existing_critical_modules + other_files
-      
+
       ohai "Compile order: #{source_files.join(", ")}"
     end
-    
+
     # Stop if no source files found
     if source_files.empty?
       odie "No source files found. Check ZIP structure."
     end
-    
+
     ENV.deparallelize
-    
+
     # Compile all files in the determined order
     object_files = []
     source_files.each do |src|
       # Skip files that don't exist (in case we extracted names from a batch file)
       next unless File.exist?(src)
-      
+
       obj_name = File.basename(src, File.extname(src)) + ".o"
-      
+
       # Skip if we've already compiled this file
       if compiled_objects.include?(obj_name)
         ohai "Skipping duplicate compilation of #{src}"
         next
       end
-      
+
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
-      
+      system "gfortran", "-c", "-J.", *compile_flags, src
+
       # Check if compilation succeeded
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
-      
+
       # Add to our tracking sets
       compiled_objects.add(obj_name)
       object_files << obj_name if File.exist?(obj_name)
     end
-    
+
     if object_files.empty?
       odie "No object files were generated. Compilation failed."
     end
-    
+
     # Ensure no duplicate object files in the link step
     unique_object_files = object_files.uniq
-    
+
     # Debug output to show what we're linking
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
-    
+
     # Link only unique object files
-    system("gfortran", "-o", "aermet", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermet", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermet")
+    bin.install "aermet"
   end
 
   test do

--- a/Formula/aermod-suite.rb
+++ b/Formula/aermod-suite.rb
@@ -2,13 +2,13 @@ class AermodSuite < Formula
   desc "Meta-formula to install AERMOD and its preprocessors (AERMET, AERMAP)"
   homepage "https://www.epa.gov/scram"
   license :public_domain
-  version "2025"
   url "https://github.com/liamswan/brew-aermod/releases/download/v20250530/aermod-suite-2025.tar.gz"
+  version "2025"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-  depends_on "aermod"
   depends_on "aermet"
   depends_on "aermap"
+  depends_on "aermod"
 
   def install
     pkgshare.install "README.md" if File.exist? "README.md"

--- a/Formula/aermod.rb
+++ b/Formula/aermod.rb
@@ -1,7 +1,9 @@
 class Aermod < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
+  require "English"
+  require "set"
   version "24142"
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/preferred/aermod/aermod_source.zip"
   sha256 "72965f60b8ee5a43a2668ef648afd9057abe3023a8738f9ab37679217fdc5940"
@@ -21,9 +23,7 @@ class Aermod < Formula
     if build.with?("version")
       version_arg = build.value("version")
       version_resource = "aermod_#{version_arg}"
-      if !resource_exists?(version_resource)
-        odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.")
-      end
+      odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.") unless resource_exists?(version_resource)
       resource(version_resource).stage { buildpath.install(Dir["*"]) }
     end
 
@@ -40,24 +40,24 @@ class Aermod < Formula
     compile_flags = ["-O2", "-fno-common"]  # Add -fno-common to prevent duplicate symbols
     compile_flags += %w[-fbounds-check -Wuninitialized] if build.with?("bounds-check")
     link_flags = %w[-O2]
-    
+
     # Clean up any existing object files to prevent conflicts
     FileUtils.rm_f Dir["*.o", "*.mod"]
-    
+
     # Check if we have a batch file to use as reference
     bat_file = "#{source_dir}/gfortran-aermod.bat"
-    
+
     # Track compiled object files to avoid duplicates
     compiled_objects = Set.new
-    
+
     if File.exist?(bat_file)
       ohai "Found gfortran-aermod.bat file, analyzing it for compilation steps"
       bat_content = File.read(bat_file)
-      
+
       # Find both compilation and linking commands
       compile_commands = []
       link_command = nil
-      
+
       # Extract compile commands in order
       bat_content.each_line do |line|
         if line =~ /gfortran\s+-c.*\.f/i
@@ -67,17 +67,17 @@ class Aermod < Formula
           link_command = line
         end
       end
-      
+
       # If we found compile commands, use them
       if compile_commands.any?
         ohai "Found #{compile_commands.size} compile commands in batch file"
         source_files = compile_commands
-        
+
         # If we found a link command, check if it specifies the object files in a specific order
         if link_command
           ohai "Found link command, analyzing object file order"
           link_objects = link_command.scan(/\s+([a-zA-Z0-9_]+\.o)\b/i).flatten
-          
+
           if link_objects.any?
             ohai "Using object file order from link command: #{link_objects.join(", ")}"
             # Convert back to source file names for compilation - try both .f and .f90 extensions
@@ -86,7 +86,7 @@ class Aermod < Formula
               base_name = obj.sub(/\.o$/, '')
               f_file = "#{base_name}.f"
               f90_file = "#{base_name}.f90"
-              
+
               if File.exist?(f_file)
                 source_files_from_link << f_file
               elsif File.exist?(f90_file)
@@ -96,7 +96,7 @@ class Aermod < Formula
                 source_files_from_link << f_file  # Default to .f extension
               end
             end
-            
+
             # Make sure we have all files - add any missing ones from compile_commands
             missing_files = compile_commands - source_files_from_link
             if missing_files.any?
@@ -114,7 +114,7 @@ class Aermod < Formula
     else
       # Define the exact compilation order based on the batch file
       ohai "No batch file found, using predefined compilation order"
-      
+
       # This is the standard order from gfortran-aermod.bat
       ordered_files = %w[
         modules.f
@@ -147,73 +147,71 @@ class Aermod < Formula
         rline.f
         bline.f
       ]
-      
+
       # Filter to only include files that exist
       all_source_files = Dir["*.f", "*.f90"]
       existing_ordered_files = ordered_files.select { |f| all_source_files.include?(f) }
-      
+
       # Add any remaining files not in our ordered list
       remaining_files = all_source_files - existing_ordered_files
       source_files = existing_ordered_files + remaining_files
-      
+
       ohai "Compile order: #{source_files.join(", ")}"
     end
-    
+
     # Stop if no source files found
     if source_files.empty?
       odie "No source files found. Check ZIP structure."
     end
-    
+
     ENV.deparallelize
-    
+
     # Compile all files in the determined order
     object_files = []
     source_files.each do |src|
       # Skip files that don't exist (in case we extracted names from a batch file)
       next unless File.exist?(src)
-      
+
       obj_name = File.basename(src, File.extname(src)) + ".o"
-      
+
       # Skip if we've already compiled this file
       if compiled_objects.include?(obj_name)
         ohai "Skipping duplicate compilation of #{src}"
         next
       end
-      
+
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
-      
+      system "gfortran", "-c", "-J.", *compile_flags, src
+
       # Check if compilation succeeded
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
-      
+
       # Add to our tracking sets
       compiled_objects.add(obj_name)
       object_files << obj_name if File.exist?(obj_name)
     end
-    
+
     if object_files.empty?
       odie "No object files were generated. Compilation failed."
     end
-    
+
     # Ensure no duplicate object files in the link step
     unique_object_files = object_files.uniq
-    
+
     # Debug output to show what we're linking
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
-    
+
     # Link only unique object files
-    system("gfortran", "-o", "aermod", *link_flags, *unique_object_files)
-    
+    system "gfortran", "-o", "aermod", *link_flags, *unique_object_files
+
     # Handle the executable
-    if File.exist?("aermod.exe")
-      mv "aermod.exe", "aermod"
-    end
-    
+    mv "aermod.exe", "aermod" if File.exist?("aermod.exe")
+
     # Install the final executable
     bin.install "aermod"
   end

--- a/Formula/aermod@24142.rb
+++ b/Formula/aermod@24142.rb
@@ -1,7 +1,9 @@
 class AermodAT24142 < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
+  require "English"
+  require "set"
   version "24142"
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/preferred/aermod/aermod_source.zip"
   sha256 "72965f60b8ee5a43a2668ef648afd9057abe3023a8738f9ab37679217fdc5940"
@@ -21,9 +23,7 @@ class AermodAT24142 < Formula
     if build.with?("version")
       version_arg = build.value("version")
       version_resource = "aermod_#{version_arg}"
-      if !resource_exists?(version_resource)
-        odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.")
-      end
+      odie("Version #{version_arg} is not available. Please choose a valid version or omit the --with-version option.") unless resource_exists?(version_resource)
       resource(version_resource).stage { buildpath.install(Dir["*"]) }
     end
 
@@ -74,39 +74,39 @@ class AermodAT24142 < Formula
       rline.f
       bline.f
     ]
-    
+
     # Filter to only include files that exist
     all_source_files = Dir["*.f", "*.f90"]
     existing_ordered_files = ordered_files.select { |f| all_source_files.include?(f) }
-    
+
     # Add any remaining files not in our ordered list
     remaining_files = all_source_files - existing_ordered_files
     source_files = existing_ordered_files + remaining_files
-    
+
     if source_files.empty?
       odie "No source files found. Check ZIP structure."
     end
-    
+
     ENV.deparallelize
-    
+
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
-      
+      system "gfortran", "-c", "-J.", *compile_flags, src
+
       # Check if compilation succeeded
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermod", *link_flags, *object_files)
+    system "gfortran", "-o", "aermod", *link_flags, *object_files
 
     # Install
-    bin.install("aermod")
+    bin.install "aermod"
   end
 
   test do


### PR DESCRIPTION
## Summary
- fix audit style issues across formulas
- reorder metadata and dependencies in `aermod-suite`
- use `$CHILD_STATUS` with English module and require `set`
- drop redundant multi-line `if` blocks and remove `.exe` rename block

## Testing
- `ruby -c Formula/aermod.rb`
- `ruby -c Formula/aermet.rb`
- `ruby -c Formula/aermap.rb`
- `ruby -c Formula/aermod-suite.rb`
- `ruby -c Formula/aermod@24142.rb`
- `ruby -c Formula/aermet@24142.rb`
- `ruby -c Formula/aermap@24142.rb`


------
https://chatgpt.com/codex/tasks/task_b_683a46066310832b8de71acd49eaa1cc