### PR TITLE
Fix brew audit style issues

### DIFF
--- a/Formula/aermap.rb
+++ b/Formula/aermap.rb
@@ -1,5 +1,5 @@
 class Aermap < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
@@ -83,7 +83,7 @@ class Aermap < Formula
             # Convert back to source file names for compilation - try both .f and .f90 extensions
             source_files_from_link = []
             link_objects.each do |obj|
-              base_name = obj.sub(/\.o$/, '')
+              base_name = obj.sub(/\.o$/, "")
               f_file = "#{base_name}.f"
               f90_file = "#{base_name}.f90"
               
@@ -93,7 +93,7 @@ class Aermap < Formula
                 source_files_from_link << f90_file
               else
                 ohai "Could not find source file for #{obj}, will try #{f_file} in compilation"
-                source_files_from_link << f_file  # Default to .f extension
+                source_files_from_link << f_file # Default to .f extension
               end
             end
             
@@ -152,9 +152,7 @@ class Aermap < Formula
     end
     
     # Stop if no source files found
-    if source_files.empty?
-      odie "No source files found. Check ZIP structure."
-    end
+    odie "No source files found. Check ZIP structure." if source_files.empty?
     
     ENV.deparallelize
     
@@ -174,12 +172,12 @@ class Aermap < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -188,9 +186,7 @@ class Aermap < Formula
       object_files << obj_name if File.exist?(obj_name)
     end
     
-    if object_files.empty?
-      odie "No object files were generated. Compilation failed."
-    end
+    odie "No object files were generated. Compilation failed." if object_files.empty?
     
     # Ensure no duplicate object files in the link step
     unique_object_files = object_files.uniq
@@ -199,10 +195,10 @@ class Aermap < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermap", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermap@24142.rb
+++ b/Formula/aermap@24142.rb
@@ -1,5 +1,5 @@
 class AermapAT24142 < Formula
-  desc "EPA AERMAP terrain processor (built from source)"
+  desc "EPA terrain processor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-related-model-support-programs#aermap"
   license :public_domain
   url "https://gaftp.epa.gov/Air/aqmg/SCRAM/models/related/aermap/aermap_source.zip"
@@ -83,22 +83,22 @@ class AermapAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermap", *link_flags, *object_files)
+    system "gfortran", "-o", "aermap", *link_flags, *object_files
 
     # Install
-    bin.install("aermap")
+    bin.install "aermap"
   end
 
   test do

--- a/Formula/aermet.rb
+++ b/Formula/aermet.rb
@@ -1,5 +1,5 @@
 class Aermet < Formula
-  desc "EPA AERMET meteorological preprocessor (built from source)"
+  desc "EPA meteorological preprocessor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/meteorological-processors-and-accessory-programs#aermet"
   license :public_domain
   version "24142"
@@ -139,12 +139,12 @@ class Aermet < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -164,10 +164,10 @@ class Aermet < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermet", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermet", *link_flags, *unique_object_files
 
     # Install
-    bin.install("aermet")
+    bin.install "aermet"
   end
 
   test do

--- a/Formula/aermet@24142.rb
+++ b/Formula/aermet@24142.rb
@@ -1,5 +1,5 @@
 class AermetAT24142 < Formula
-  desc "EPA AERMET meteorological preprocessor (built from source)"
+  desc "EPA meteorological preprocessor for AERMOD (built from source)"
   homepage "https://www.epa.gov/scram/meteorological-processors-and-accessory-programs#aermet"
   license :public_domain
   version "24142"
@@ -73,22 +73,22 @@ class AermetAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermet", *link_flags, *object_files)
+    system "gfortran", "-o", "aermet", *link_flags, *object_files
 
     # Install
-    bin.install("aermet")
+    bin.install "aermet"
   end
 
   test do

--- a/Formula/aermod-suite.rb
+++ b/Formula/aermod-suite.rb
@@ -1,14 +1,14 @@
 class AermodSuite < Formula
   desc "Meta-formula to install AERMOD and its preprocessors (AERMET, AERMAP)"
   homepage "https://www.epa.gov/scram"
+  url "https://github.com/liamswan/brew-aermod/releases/download/v20250530/aermod-suite-2025.tar.gz"
   license :public_domain
   version "2025"
-  url "https://github.com/liamswan/brew-aermod/releases/download/v20250530/aermod-suite-2025.tar.gz"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-  depends_on "aermod"
-  depends_on "aermet"
   depends_on "aermap"
+  depends_on "aermet"
+  depends_on "aermod"
 
   def install
     pkgshare.install "README.md" if File.exist? "README.md"

--- a/Formula/aermod.rb
+++ b/Formula/aermod.rb
@@ -1,5 +1,5 @@
 class Aermod < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
   version "24142"
@@ -83,7 +83,7 @@ class Aermod < Formula
             # Convert back to source file names for compilation - try both .f and .f90 extensions
             source_files_from_link = []
             link_objects.each do |obj|
-              base_name = obj.sub(/\.o$/, '')
+              base_name = obj.sub(/\.o$/, "")
               f_file = "#{base_name}.f"
               f90_file = "#{base_name}.f90"
               
@@ -93,7 +93,7 @@ class Aermod < Formula
                 source_files_from_link << f90_file
               else
                 ohai "Could not find source file for #{obj}, will try #{f_file} in compilation"
-                source_files_from_link << f_file  # Default to .f extension
+                source_files_from_link << f_file # Default to .f extension
               end
             end
             
@@ -160,9 +160,7 @@ class Aermod < Formula
     end
     
     # Stop if no source files found
-    if source_files.empty?
-      odie "No source files found. Check ZIP structure."
-    end
+    odie "No source files found. Check ZIP structure." if source_files.empty?
     
     ENV.deparallelize
     
@@ -182,12 +180,12 @@ class Aermod < Formula
       
       # Make sure we can find module files during compilation
       ohai "Compiling #{src}"
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}, checking for the file..."
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
       
@@ -196,9 +194,7 @@ class Aermod < Formula
       object_files << obj_name if File.exist?(obj_name)
     end
     
-    if object_files.empty?
-      odie "No object files were generated. Compilation failed."
-    end
+    odie "No object files were generated. Compilation failed." if object_files.empty?
     
     # Ensure no duplicate object files in the link step
     unique_object_files = object_files.uniq
@@ -207,7 +203,7 @@ class Aermod < Formula
     ohai "Linking #{unique_object_files.size} object files: #{unique_object_files.join(", ")}"
     
     # Link only unique object files
-    system("gfortran", "-o", "aermod", *link_flags, *unique_object_files)
+    system "gfortran", "-o", "aermod", *link_flags, *unique_object_files
     
     # Handle the executable
     if File.exist?("aermod.exe")

--- a/Formula/aermod@24142.rb
+++ b/Formula/aermod@24142.rb
@@ -1,5 +1,5 @@
 class AermodAT24142 < Formula
-  desc "EPA AERMOD air dispersion model (built from source)"
+  desc "EPA air dispersion model (built from source)"
   homepage "https://www.epa.gov/scram/air-quality-dispersion-modeling-preferred-and-recommended-models#aermod"
   license :public_domain
   version "24142"
@@ -91,22 +91,22 @@ class AermodAT24142 < Formula
     
     # Compile all files in the determined order
     source_files.each do |src|
-      system("gfortran", "-c", "-J.", *compile_flags, src)
+      system "gfortran", "-c", "-J.", *compile_flags, src
       
       # Check if compilation succeeded
       unless $?.success?
         ohai "Failed to compile #{src}"
-        system("ls", "-la", src) if File.exist?(src)
+        system "ls", "-la", src if File.exist?(src)
         odie "Compilation failed for #{src}"
       end
     end
 
     # Link everything
     object_files = source_files.map { |f| File.basename(f, File.extname(f)) + ".o" }
-    system("gfortran", "-o", "aermod", *link_flags, *object_files)
+    system "gfortran", "-o", "aermod", *link_flags, *object_files
 
     # Install
-    bin.install("aermod")
+    bin.install "aermod"
   end
 
   test do


### PR DESCRIPTION
## Summary
- fix quoting and whitespace errors for `aermap`
- sort dependencies and reorder fields in `aermod-suite`
- style fixes for `aermod`

## Testing
- `ruby -c Formula/aermap.rb`
- `ruby -c Formula/aermod.rb`
- `ruby -c Formula/aermod-suite.rb`
- `for f in Formula/*.rb; do ruby -c $f; done`

------
https://chatgpt.com/codex/tasks/task_b_683a46066310832b8de71acd49eaa1cc