### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/liamswan/brew-aermod/security/code-scanning/1](https://github.com/liamswan/brew-aermod/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow (auditing, installing, and testing formulas), the workflow likely only requires `contents: read` permissions. Adding this block at the root level of the workflow ensures that all jobs inherit these permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
